### PR TITLE
CC2-448 - HAPI FHIR Docker Image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.orig
 target/
 *.iml
+_Notes_/
 
 # Compiled class file
 *.class

--- a/README-Cambian.md
+++ b/README-Cambian.md
@@ -1,0 +1,68 @@
+
+## Configuration
+Changes have been made to the application.yml for:
+ * use Postgres as the database
+ * use Flyway to provision the database schema
+ * enable partitioning based on URL (multi-tenant)
+
+__NOTE__:  The database password should be changed for production by using environment variable.
+
+## Local testing
+Start Postgres in Docker (first ensure docker is running on your PC)
+```bash
+docker compose -f docker-compose-postgres.yml up hapi-fhir-postgres
+```
+
+Use maven command to start local JVM process
+```bash
+mvn spring-boot:run
+```
+Also see [Spring Boot section in HAPI README.md](./README.md#using-spring-boot)
+
+
+## Build a deployable package for Docker
+
+To build the docker image, run
+```bash
+docker build -t hapi-fhir/hapi-fhir-jpaserver-cambian .
+```
+
+To test the docker image in local docker, run
+```bash
+docker run -p 8080:8080 hapi-fhir/hapi-fhir-jpaserver-cambian:latest
+```
+The image can then be copied to AWS ECS (Elastic Container Server), talk to devops about this.
+
+Also see [Docker section in HAPI README.md](./README.md#using-the-dockerfile-and-multistage-build)
+
+
+## Deploy to AWS ECS
+
+1. Retrieve an authentication token and authenticate your Docker client to your registry. Use the AWS TOOLS 
+  * for __PowerShell__:
+    ```
+    (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin 975050054044.dkr.ecr.ca-central-1.amazonaws.com
+    ```
+      Note: If you receive an error using the AWS TOOLS for PowerShell, make sure that you have the latest version of the AWS TOOLS for PowerShell and Docker installed.
+
+  * Or, for a __bash shell__:
+    ``` 
+    aws ecr get-login-password --profile cambian-dev | docker login --username AWS --password-stdin 975050054044.dkr.ecr.ca-central-1.amazonaws.com  
+    ```
+    (see https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecr/get-login-password.html)
+
+2. Build your Docker image if not already built
+    ```
+    docker build -t cambian-devhapi-fhir .
+    ```
+3. After the build completes, tag your image so you can push the image to this repository:
+    ```
+    docker tag cambian-devhapi-fhir:latest 975050054044.dkr.ecr.ca-central-1.amazonaws.com/cambian-devhapi-fhir:latest
+    ```
+4. Run the following command to push this image to your newly created AWS repository:
+    ``` 
+    docker push 975050054044.dkr.ecr.ca-central-1.amazonaws.com/cambian-devhapi-fhir:latest
+    ```
+The image is must be built for x86:sunrise:
+After you finish uploading, just let me know with the list of environment variables!
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Also see [README-Cambian.md./](README-Cambian.md) for local info
+
 # HAPI-FHIR Starter Project
 
 This project is a complete starter project you can use to deploy a FHIR server using HAPI FHIR JPA.

--- a/build-docker-image.bat
+++ b/build-docker-image.bat
@@ -1,1 +1,1 @@
-docker build -t hapi-fhir/hapi-fhir-jpaserver-starter .
+docker build -t hapi-fhir/hapi-fhir-jpaserver-cambian .

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-docker build -t hapi-fhir/hapi-fhir-jpaserver-starter .
+docker build -t hapi-fhir/hapi-fhir-jpaserver-cambian .
 

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+
+  hapi-fhir-postgres:
+    image: postgres:15-alpine
+    container_name: hapi-fhir-postgres
+    restart: always
+    environment:
+      POSTGRES_DB: "hapi_fhir_db"
+      POSTGRES_USER: "hapi_fhir_user"
+      POSTGRES_PASSWORD: "hapi_fhir_password"
+    ports:
+      - "5432:5432"
+    volumes:
+      - hapi-fhir-postgres:/var/lib/postgresql/data
+
+  hapi-fhir-jpaserver:
+    # build: .
+    image: hapi-fhir/hapi-fhir-jpaserver-cambian:latest
+    container_name: hapi-fhir-jpaserver
+    restart: on-failure
+    ports:
+      - "8080:8080"
+
+volumes:
+  hapi-fhir-postgres:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,16 +15,18 @@ spring:
     allow-circular-references: true
     #allow-bean-definition-overriding: true
   flyway:
-    enabled: false
+    enabled: true
     baselineOnMigrate: true
     fail-on-missing-locations: false
   datasource:
-    #url: 'jdbc:h2:file:./target/database/h2'
-    url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
-    max-active: 15
+    url: 'jdbc:postgresql://localhost:5432/hapi_fhir_db'
+    username: admin
+    password: admin
+    driverClassName: org.postgresql.Driver
+    ## Override these value with the following environment variables in docker container
+    # SPRING_DATASOURCE_URL: 'jdbc:postgresql://localhost:5432/hapi_fhir_db'
+    # SPRING_DATASOURCE_USERNAME: admin
+    # SPRING_DATASOURCE_PASSWORD: admin
 
     # database connection pool size
     hikari:
@@ -33,11 +35,12 @@ spring:
     properties:
       hibernate.format_sql: false
       hibernate.show_sql: false
+      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
 
       #Hibernate dialect is automatically detected except Postgres and H2.
       #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
       #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
-      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+      
   #      hibernate.hbm2ddl.auto: update
   #      hibernate.jdbc.batch_size: 20
   #      hibernate.cache.use_query_cache: false
@@ -159,9 +162,9 @@ hapi:
       - https://unitsofmeasure.org/*
       - http://loinc.org/*
       - https://loinc.org/*
-    #    partitioning:
-    #      allow_references_across_partitions: false
-    #      partitioning_include_in_search_hashes: false
+    partitioning:
+      allow_references_across_partitions: false
+      partitioning_include_in_search_hashes: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-


### PR DESCRIPTION
- enable partitioning in application.yaml file
- set default database config to postgres in application.yaml
- add build/deploy instructions to README-Cambian.md file
- test instructions with local docker and with AWS ECR